### PR TITLE
test: use runtime arguments in Divan benchmarks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -318,9 +318,9 @@ dependencies = [
 
 [[package]]
 name = "divan"
-version = "0.1.8"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbf174e1957cfadab3bcb040afb210ea8b7c2ffc094eb88b750be61fc601835e"
+checksum = "5398159ee27f2b123d89b856bad61725442f37df5fb98c30cd570c318d594aee"
 dependencies = [
  "cfg-if",
  "clap",
@@ -332,9 +332,9 @@ dependencies = [
 
 [[package]]
 name = "divan-macros"
-version = "0.1.8"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "510ef69263e119c8ec0213761e397d26a3f6d35e13a454549508446d3578ddc0"
+checksum = "5092f66eb3563a01e85552731ae82c04c934ff4efd7ad1a0deae7b948f4b3ec4"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/crates/mabo-benches/Cargo.toml
+++ b/crates/mabo-benches/Cargo.toml
@@ -28,7 +28,7 @@ mabo-parser = { path = "../mabo-parser" }
 mimalloc.workspace = true
 
 [dev-dependencies]
-divan = "0.1.8"
+divan = "0.1.11"
 indoc.workspace = true
 
 [lints]

--- a/crates/mabo-benches/benches/compiler.rs
+++ b/crates/mabo-benches/benches/compiler.rs
@@ -9,18 +9,18 @@ fn main() {
     divan::main();
 }
 
-#[divan::bench(consts = [1, 10, 100, 1000])]
-fn validate_large_schema<const N: usize>(bencher: Bencher<'_, '_>) {
-    let schema = mabo_benches::generate_schema(N);
+#[divan::bench(args = [1, 10, 100, 1000])]
+fn validate_large_schema(bencher: Bencher<'_, '_>, n: usize) {
+    let schema = mabo_benches::generate_schema(n);
     let schema = mabo_parser::Schema::parse(&schema, None).unwrap();
     mabo_compiler::validate_schema(&schema).unwrap();
 
     bencher.bench(|| mabo_compiler::validate_schema(black_box(&schema)));
 }
 
-#[divan::bench(consts = [1, 10, 100, 1000])]
-fn resolve_large_schema<const N: usize>(bencher: Bencher<'_, '_>) {
-    let schema = mabo_benches::generate_schema(N);
+#[divan::bench(args = [1, 10, 100, 1000])]
+fn resolve_large_schema(bencher: Bencher<'_, '_>, n: usize) {
+    let schema = mabo_benches::generate_schema(n);
     let schema = mabo_parser::Schema::parse(&schema, None).unwrap();
     mabo_compiler::validate_schema(&schema).unwrap();
 
@@ -29,9 +29,9 @@ fn resolve_large_schema<const N: usize>(bencher: Bencher<'_, '_>) {
     bencher.bench(|| mabo_compiler::resolve_schemas(black_box(list)));
 }
 
-#[divan::bench(consts = [1, 10, 100, 1000])]
-fn simplify_large_schema<const N: usize>(bencher: Bencher<'_, '_>) {
-    let schema = mabo_benches::generate_schema(N);
+#[divan::bench(args = [1, 10, 100, 1000])]
+fn simplify_large_schema(bencher: Bencher<'_, '_>, n: usize) {
+    let schema = mabo_benches::generate_schema(n);
     let schema = mabo_parser::Schema::parse(&schema, None).unwrap();
     let _ = mabo_compiler::simplify_schema(&schema);
 

--- a/crates/mabo-benches/benches/parser.rs
+++ b/crates/mabo-benches/benches/parser.rs
@@ -48,17 +48,17 @@ fn basic(bencher: Bencher<'_, '_>) {
     bencher.bench(|| mabo_parser::Schema::parse(black_box(input), None));
 }
 
-#[divan::bench(consts = [1, 10, 100, 1000])]
-fn large_schema<const N: usize>(bencher: Bencher<'_, '_>) {
-    let schema = mabo_benches::generate_schema(N);
+#[divan::bench(args = [1, 10, 100, 1000])]
+fn large_schema(bencher: Bencher<'_, '_>, n: usize) {
+    let schema = mabo_benches::generate_schema(n);
     mabo_parser::Schema::parse(&schema, None).unwrap();
 
     bencher.bench(|| mabo_parser::Schema::parse(black_box(&schema), None));
 }
 
-#[divan::bench(consts = [1, 10, 100, 1000])]
-fn print<const N: usize>(bencher: Bencher<'_, '_>) {
-    let schema = mabo_benches::generate_schema(N);
+#[divan::bench(args = [1, 10, 100, 1000])]
+fn print(bencher: Bencher<'_, '_>, n: usize) {
+    let schema = mabo_benches::generate_schema(n);
     let schema = mabo_parser::Schema::parse(&schema, None).unwrap();
 
     bencher.bench(|| black_box(&schema).to_string());

--- a/crates/mabo-benches/benches/varint.rs
+++ b/crates/mabo-benches/benches/varint.rs
@@ -49,32 +49,32 @@ impl Signed for Bincode {
 
 #[divan::bench(
     types = [Leb128, Bincode],
-    consts = [
+    args = [
         1,
-        u8::MAX as u128,
-        u16::MAX as u128,
-        u32::MAX as u128,
-        u64::MAX as u128,
+        u8::MAX.into(),
+        u16::MAX.into(),
+        u32::MAX.into(),
+        u64::MAX.into(),
         u128::MAX,
     ],
 )]
-fn unsigned<const N: u128, T: Unsigned>() -> u128 {
+fn unsigned<T: Unsigned>(n: u128) -> u128 {
     let mut buf = [0; 19];
-    T::run(black_box(N), black_box(&mut buf))
+    T::run(n, black_box(&mut buf))
 }
 
 #[divan::bench(
     types = [Leb128, Bincode],
-    consts = [
+    args = [
         -1,
-        i8::MIN as i128,
-        i16::MIN as i128,
-        i32::MIN as i128,
-        i64::MIN as i128,
+        i8::MIN.into(),
+        i16::MIN.into(),
+        i32::MIN.into(),
+        i64::MIN.into(),
         i128::MIN,
     ],
 )]
-fn signed<const N: i128, T: Signed>() -> i128 {
+fn signed<T: Signed>(n: i128) -> i128 {
     let mut buf = [0; 19];
-    T::run(black_box(N), black_box(&mut buf))
+    T::run(n, black_box(&mut buf))
 }


### PR DESCRIPTION
The new [`args`](https://docs.rs/divan/latest/divan/attr.bench.html#args) option greatly reduces compile times and is not limited to arrays/slices.